### PR TITLE
Use Object.assign instead of depending on js.merge

### DIFF
--- a/lib/hooks/protocol.js
+++ b/lib/hooks/protocol.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var assert = require('assert');
-var merge = require('merge');
 var Message = require('../message');
 
 /**
@@ -33,7 +32,7 @@ module.exports = function ProtocolFactory(protocolspec) {
     method.call(rpc, message.params, function(err, result) {
       var reply = new Message({
         error: err,
-        result:  merge({ contact: rpc._contact }, result),
+        result:  Object.assign({ contact: rpc._contact }, result),
         id: message.id
       });
 

--- a/lib/message.js
+++ b/lib/message.js
@@ -2,7 +2,6 @@
 
 var constants = require('./constants');
 var hat = require('hat');
-var merge = require('merge');
 
 /**
  * Represents a [JSON-RPC 2.0](http://www.jsonrpc.org/specification) request or
@@ -35,7 +34,7 @@ function Message(spec) {
     this.params = spec.params;
   } else if (Message.isResponse(spec)) {
     this.id = spec.id;
-    this.result = merge({}, spec.result);
+    this.result = Object.assign({}, spec.result);
     if (spec.error) {
       this.error = {
         code: -32603,

--- a/lib/node.js
+++ b/lib/node.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var merge = require('merge');
 var assert = require('assert');
 var async = require('async');
 var inherits = require('util').inherits;
@@ -22,7 +21,7 @@ var Logger = require('./logger');
  * @param {Function} options.validator - Key-Value validation function
  */
 function Node(options) {
-  options = merge(Object.create(Node.DEFAULTS), options);
+  options = Object.assign(Object.create(Node.DEFAULTS), options);
 
   if (!(this instanceof Node)) {
     return new Node(options);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "kad-localstorage": "0.0.7",
     "kad-memstore": "0.0.1",
     "lodash": "^4.17.11",
-    "merge": "^1.2.0",
     "ms": "^0.7.0",
     "msgpack5": "^3.3.0"
   },


### PR DESCRIPTION
There's a prototype pollution bug in js.merge that requires a major
version bump to upgrade.  However, the uses here don't seem to need any
of the features beyond what Object.assign provides, so it's probably
easier just to remove the dependency.

@wikimedia/parsing @wikimedia/services 