### PR TITLE
Release under @wikimedia/kad-fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "kad",
+  "name": "@wikimedia/kad-fork",
   "version": "1.3.6",
-  "description": "implementation of the kademlia dht for node",
+  "description": "Wikimedia-specific fork of kad package",
   "main": "index.js",
   "directories": {
     "test": "test",
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadtools/kad.git"
+    "url": "https://github.com/wikimedia/kad.git"
   },
   "author": "Gordon Hall <gordon@gordonwritescode.com>",
   "contributors": [


### PR DESCRIPTION
Requiring a fork via ssh or git+https seem to be broken
in various ways in various versions of NPM in WMF CI and
Debian Bullseye, so release the package under a separate
name to be able to depend on it in a regular way.