### PR TITLE
Revert "Release under @wikimedia/kad-fork"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@wikimedia/kad-fork",
+  "name": "kad",
   "version": "1.3.6",
-  "description": "Wikimedia-specific fork of kad package",
+  "description": "implementation of the kademlia dht for node",
   "main": "index.js",
   "directories": {
     "test": "test",
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/wikimedia/kad.git"
+    "url": "https://github.com/kadtools/kad.git"
   },
   "author": "Gordon Hall <gordon@gordonwritescode.com>",
   "contributors": [


### PR DESCRIPTION
Reverts wikimedia/kad#5 temporarily while I figure out npmjs access issues.